### PR TITLE
Add windows library to linker

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -24,6 +24,12 @@ if env["platform"] == "macos":
         ),
         source=sources,
     )
+elif env["platform"] == "windows":
+    env.Append(LIBS=["ws2_32"])
+    library = env.SharedLibrary(
+        "build/libgdraknet{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),
+        source=sources,
+    )
 else:
     library = env.SharedLibrary(
         "build/libgdraknet{}{}".format(env["suffix"], env["SHLIBSUFFIX"]),


### PR DESCRIPTION
Tried to build it on windows, didn't work, searched around a bit and found that on windows you need to add some standard libraries to the linker path yourself, so I added an option in the config script to do just that.